### PR TITLE
feat: Add content type and URL pattern filtering to HAR save

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,9 +593,11 @@ X Y coordinate space, based on the provided screenshot.
 
 - **browser_har_save**
   - Title: Save HAR file
-  - Description: Save HTTP Archive (HAR) file of all network traffic captured during the browser session
+  - Description: Save HTTP Archive (HAR) file of all network traffic captured during the browser session. Supports filtering by content type and URL patterns.
   - Parameters:
     - `filename` (string, optional): File name to save the HAR to. Defaults to `session-{timestamp}.har` if not specified.
+    - `contentTypes` (array, optional): Array of MIME types to include (e.g., ["application/javascript", "text/css"]). If not specified, all content types are included.
+    - `urlPattern` (string, optional): URL pattern to match (supports wildcards with * and ?). Only requests matching this pattern will be included. If not specified, all URLs are included.
   - Read-only: **true**
 
 <!-- NOTE: This has been generated via update-readme.js -->


### PR DESCRIPTION
## Summary
Extends the `browser_har_save` tool with filtering capabilities to allow selective HAR capture based on content type and URL patterns.

## Features Added
- **Content Type Filtering**: Filter HAR entries by MIME types (e.g., `["application/javascript", "text/css"]`)
- **URL Pattern Filtering**: Filter entries by URL patterns with wildcard support (e.g., `"*/api/*"`)
- **Combined Filtering**: Apply both filters simultaneously for precise control
- **HAR 1.2 Compliance**: All filtered outputs remain valid HAR 1.2 format
- **User Feedback**: Tool responses include information about applied filters

## Example Usage
```javascript
// Save only JavaScript files
await browser_har_save({
  contentTypes: ["application/javascript"]
});

// Save only API calls
await browser_har_save({
  urlPattern: "*/api/*"
});

// Combined filtering
await browser_har_save({
  contentTypes: ["application/javascript"],
  urlPattern: "*/api/*"
});
```

## Implementation Details
- Extended tool schema with optional `contentTypes` and `urlPattern` parameters
- Added `generateFilteredHAR()` method to HARRecorder class
- Wildcard URL matching with case-insensitive support
- Comprehensive test coverage for all filtering scenarios
- Maintains backward compatibility

## Test Plan
- [x] Content type filtering tests
- [x] URL pattern filtering tests  
- [x] Combined filtering tests
- [x] Edge case handling (no matches)
- [x] HAR 1.2 validation
- [x] Backward compatibility
- [x] Linting and code style compliance

🤖 Generated with [Claude Code](https://claude.ai/code)